### PR TITLE
Add plan CRUD with vendor relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/node_modules/
+.env

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Plan;
+use App\Models\Vendor;
+use App\Models\MenuItem;
+use Illuminate\Http\Request;
+
+class PlanController extends Controller
+{
+    public function index()
+    {
+        $plans = Plan::with('menuItems')->get();
+        return view('plans.index', compact('plans'));
+    }
+
+    public function create()
+    {
+        $vendors = Vendor::all();
+        $menuItems = MenuItem::all();
+        return view('plans.create', compact('vendors', 'menuItems'));
+    }
+
+    public function store(Request $request)
+    {
+        $plan = Plan::create($request->validate([
+            'name' => 'required|string',
+            'vendor_id' => 'required|exists:vendors,id',
+        ]));
+
+        $items = $request->input('items', []);
+        foreach ($items as $itemId => $portion) {
+            if ($portion) {
+                $plan->menuItems()->attach($itemId, ['portion' => $portion]);
+            }
+        }
+
+        return redirect()->route('plans.index');
+    }
+
+    public function edit(Plan $plan)
+    {
+        $vendors = Vendor::all();
+        $menuItems = MenuItem::all();
+        $plan->load('menuItems');
+        return view('plans.edit', compact('plan', 'vendors', 'menuItems'));
+    }
+
+    public function update(Request $request, Plan $plan)
+    {
+        $plan->update($request->validate([
+            'name' => 'required|string',
+            'vendor_id' => 'required|exists:vendors,id',
+        ]));
+
+        $plan->menuItems()->detach();
+        $items = $request->input('items', []);
+        foreach ($items as $itemId => $portion) {
+            if ($portion) {
+                $plan->menuItems()->attach($itemId, ['portion' => $portion]);
+            }
+        }
+
+        return redirect()->route('plans.index');
+    }
+
+    public function destroy(Plan $plan)
+    {
+        $plan->menuItems()->detach();
+        $plan->delete();
+        return redirect()->route('plans.index');
+    }
+}

--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MenuItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'vendor_id',
+        'name',
+        'price',
+    ];
+
+    public function vendor()
+    {
+        return $this->belongsTo(Vendor::class);
+    }
+
+    public function plans()
+    {
+        return $this->belongsToMany(Plan::class)->withPivot('portion');
+    }
+}

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Plan extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'vendor_id',
+        'name',
+    ];
+
+    public function vendor()
+    {
+        return $this->belongsTo(Vendor::class);
+    }
+
+    public function menuItems()
+    {
+        return $this->belongsToMany(MenuItem::class)->withPivot('portion');
+    }
+}

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Vendor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function menuItems()
+    {
+        return $this->hasMany(MenuItem::class);
+    }
+
+    public function plans()
+    {
+        return $this->hasMany(Plan::class);
+    }
+}

--- a/database/migrations/2025_07_27_000001_create_vendors_table.php
+++ b/database/migrations/2025_07_27_000001_create_vendors_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vendors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vendors');
+    }
+};

--- a/database/migrations/2025_07_27_000002_create_menu_items_table.php
+++ b/database/migrations/2025_07_27_000002_create_menu_items_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('menu_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('vendor_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->decimal('price', 8, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('menu_items');
+    }
+};

--- a/database/migrations/2025_07_27_000003_create_plans_table.php
+++ b/database/migrations/2025_07_27_000003_create_plans_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('plans', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('vendor_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plans');
+    }
+};

--- a/database/migrations/2025_07_27_000004_create_plan_menu_item_table.php
+++ b/database/migrations/2025_07_27_000004_create_plan_menu_item_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('plan_menu_item', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('plan_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('menu_item_id')->constrained()->cascadeOnDelete();
+            $table->string('portion');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plan_menu_item');
+    }
+};

--- a/resources/views/plans/create.blade.php
+++ b/resources/views/plans/create.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Create Plan</title>
+</head>
+<body>
+    <h1>Create Plan</h1>
+    <form method="POST" action="{{ route('plans.store') }}">
+        @csrf
+        <div>
+            <label>Name</label>
+            <input type="text" name="name" required>
+        </div>
+        <div>
+            <label>Vendor</label>
+            <select name="vendor_id" required>
+                @foreach($vendors as $vendor)
+                    <option value="{{ $vendor->id }}">{{ $vendor->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <h3>Menu Items</h3>
+            @foreach($menuItems as $item)
+                <div>
+                    <label>{{ $item->name }}</label>
+                    <input type="text" name="items[{{ $item->id }}]" placeholder="portion">
+                </div>
+            @endforeach
+        </div>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/resources/views/plans/edit.blade.php
+++ b/resources/views/plans/edit.blade.php
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Edit Plan</title>
+</head>
+<body>
+    <h1>Edit Plan</h1>
+    <form method="POST" action="{{ route('plans.update', $plan) }}">
+        @csrf
+        @method('PUT')
+        <div>
+            <label>Name</label>
+            <input type="text" name="name" value="{{ $plan->name }}" required>
+        </div>
+        <div>
+            <label>Vendor</label>
+            <select name="vendor_id" required>
+                @foreach($vendors as $vendor)
+                    <option value="{{ $vendor->id }}" @selected($plan->vendor_id == $vendor->id)>{{ $vendor->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <h3>Menu Items</h3>
+            @foreach($menuItems as $item)
+                <div>
+                    <label>{{ $item->name }}</label>
+                    <input type="text" name="items[{{ $item->id }}]" value="{{ $plan->menuItems->find($item->id)?->pivot->portion }}" placeholder="portion">
+                </div>
+            @endforeach
+        </div>
+        <button type="submit">Update</button>
+    </form>
+</body>
+</html>

--- a/resources/views/plans/index.blade.php
+++ b/resources/views/plans/index.blade.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Plans</title>
+</head>
+<body>
+    <h1>Plans</h1>
+    <a href="{{ route('plans.create') }}">Create Plan</a>
+    <table border="1" cellpadding="5" cellspacing="0">
+        <tr>
+            <th>Name</th>
+            <th>Vendor</th>
+            <th>Menu Items</th>
+            <th>Actions</th>
+        </tr>
+        @foreach($plans as $plan)
+        <tr>
+            <td>{{ $plan->name }}</td>
+            <td>{{ $plan->vendor->name }}</td>
+            <td>
+                <ul>
+                @foreach($plan->menuItems as $item)
+                    <li>{{ $item->name }} - {{ $item->pivot->portion }}</li>
+                @endforeach
+                </ul>
+            </td>
+            <td>
+                <a href="{{ route('plans.edit', $plan) }}">Edit</a>
+                <form method="POST" action="{{ route('plans.destroy', $plan) }}" style="display:inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" onclick="return confirm('Delete?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </table>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PlanController;
+
+Route::resource('plans', PlanController::class);


### PR DESCRIPTION
## Summary
- add migrations for vendors, menu items, plans and plan menu item pivot
- create Eloquent models for Vendor, MenuItem and Plan
- implement PlanController and resource routes
- add minimal Blade views for listing, creating and editing plans
- ignore vendor and node_modules

## Testing
- `composer validate --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_68869654b0948330bd5ade1e376d1d46